### PR TITLE
Stop using Symbol keys

### DIFF
--- a/src/reknow/Entities.ts
+++ b/src/reknow/Entities.ts
@@ -4,6 +4,7 @@ import {EntitiesState} from "./EntitiesState"
 import {EntityClass} from "./Types"
 import {EntitiesDeclarations} from "./EntitiesDeclarations"
 import {ById} from "./Types"
+import {addNonEnumerableProperty} from "./Utils"
 
 export class Entities<E extends Entity> {
   _entitiesState: EntitiesState<E> | null = null
@@ -80,7 +81,7 @@ export class Entities<E extends Entity> {
     entityClass: EntityClass<E>,
     entities: Entities<E>
   ) {
-    entityClass[ENTITIES_KEY] = entities
+    addNonEnumerableProperty(entityClass, ENTITIES_KEY, entities)
   }
 
   // FIXME - factor this out into Utils of Entity, Entities, and Service

--- a/src/reknow/EntitiesDeclarations.ts
+++ b/src/reknow/EntitiesDeclarations.ts
@@ -6,6 +6,7 @@ import {FunctionType} from "./Types"
 import {Entities} from "./Entities"
 import {indexTermsToSchema} from "./Utils"
 import {uniqueIndexTermsToSchema} from "./Utils"
+import {addNonEnumerableProperty} from "./Utils"
 
 /** Stores the declarations, typically made with @ decorators,
  * specified in an Entities class.  The declarations are associated
@@ -99,7 +100,7 @@ export class EntitiesDeclarations {
     ]
     if (ret == null) {
       ret = new EntitiesDeclarations()
-      ;(proto as any)[ENTITIES_DECLARATIONS_KEY] = ret
+      addNonEnumerableProperty(proto, ENTITIES_DECLARATIONS_KEY, ret)
     }
     return ret
   }
@@ -111,4 +112,4 @@ export class EntitiesDeclarations {
   }
 }
 
-export const ENTITIES_DECLARATIONS_KEY = Symbol("ENTITIES_DECLARATIONS_KEY")
+export const ENTITIES_DECLARATIONS_KEY = "__ENTITIES_DECLARATIONS_KEY"

--- a/src/reknow/Entity.ts
+++ b/src/reknow/Entity.ts
@@ -6,12 +6,13 @@ import {EntityClass} from "./Types"
 import {HasManyOptions} from "./Types"
 import {HasOneOptions} from "./Types"
 import {BelongsToOptions} from "./Types"
+import {addNonEnumerableProperty} from "./Utils"
 
-export const ENTITY_STATE_KEY = Symbol("ENTITY_STATE_KEY")
-export const ENTITIES_KEY = Symbol("ENTITIES_KEY")
+export const ENTITY_STATE_KEY = "__ENTITY_STATE_KEY"
+export const ENTITIES_KEY = "__ENTITIES_KEY"
 
 export abstract class Entity {
-  [ENTITY_STATE_KEY]: EntityState<any> | null = null
+  [ENTITY_STATE_KEY]: EntityState<any> | null
   get entityState() {
     return notNull(this[ENTITY_STATE_KEY])
   }

--- a/src/reknow/Proxied.ts
+++ b/src/reknow/Proxied.ts
@@ -266,5 +266,5 @@ export abstract class Proxied<P extends Object, T extends Object>
   }
 }
 
-const TARGET = Symbol("TARGET")
-const PROXIED = Symbol("PROXIED")
+const TARGET = "__TARGET_KEY"
+const PROXIED = "__PROXIED_KEY"

--- a/src/reknow/ServiceDeclarations.ts
+++ b/src/reknow/ServiceDeclarations.ts
@@ -3,6 +3,7 @@ import {ReactionDecorator} from "./Types"
 import {replaceFunction} from "./Utils"
 import {Service} from "./Service"
 import {FunctionType} from "./Types"
+import {addNonEnumerableProperty} from "./Utils"
 
 /** Stores the declarations, typically made with @ decorators,
  * specified in a Services class.  The declarations are associated
@@ -78,7 +79,7 @@ export class ServiceDeclarations {
     ]
     if (ret == null) {
       ret = new ServiceDeclarations()
-      ;(proto as any)[SERVICE_DECLARATIONS_KEY] = ret
+      addNonEnumerableProperty(proto, SERVICE_DECLARATIONS_KEY, ret)
     }
     return ret
   }
@@ -90,4 +91,4 @@ export class ServiceDeclarations {
   }
 }
 
-export const SERVICE_DECLARATIONS_KEY = Symbol("SERVICE_DECLARATIONS_KEY")
+export const SERVICE_DECLARATIONS_KEY = "__SERVICE_DECLARATIONS_KEY"

--- a/src/reknow/Utils.ts
+++ b/src/reknow/Utils.ts
@@ -710,7 +710,7 @@ export function removeProperty<T>(target: Object, name: string) {
 
 export function addNonEnumerableProperty<T>(
   target: Object,
-  name: symbol,
+  name: string|symbol,
   value: T
 ) {
   const pd: PropertyDescriptor = {value, enumerable: false}


### PR DESCRIPTION
Fixes #13

Reknow uses special keys to associate objects, such as Entity class with Entities instance, or an Entity instance with its associated EntityState.  These keys were Symbols, which served the purpose of essentially making those associations only visible and accessible within Renow.

Unfortunately, this created a problem for applications in which reknow is imported multiple times, such as an application importing reknow, and also importing another library that also imports reknow.  In these cases, Entities can't be shared between the libraries since the Symbol keys from one library instance aren't visible to the other.

This is fixed by removing the Symbol keys and replacing them with string keys, but making them non-enumerable so that they remain mostly invisible, even if they aren't totally inaccessible.