### PR TITLE
Proxied now ignores get/set for getters or setters

### DIFF
--- a/src/reknow/Proxied.ts
+++ b/src/reknow/Proxied.ts
@@ -1,5 +1,5 @@
 import {StateManager} from "./StateManager"
-import {isNonInheritedProperty} from "./Utils"
+import {isNonInheritedProperty, isSetter, isGetter} from "./Utils"
 import {ObjectChangePublishers} from "./ObjectChangePublishers"
 
 /** Superclass for objects that expose their state to the application
@@ -127,6 +127,8 @@ export abstract class Proxied<P extends Object, T extends Object>
       return target
     } else if (prop === PROXIED) {
       return this
+    } else if (isGetter(target, prop)) {
+      return Reflect.get(target, prop, receiver)
     } else if (typeof prop === "string") {
       return this.propertyGet(prop)
     } else {
@@ -135,7 +137,9 @@ export abstract class Proxied<P extends Object, T extends Object>
   }
 
   set(target: Object, prop: PropertyKey, value: any, receiver: Object) {
-    if (typeof prop === "string") {
+    if (isSetter(target, prop)) {
+      return Reflect.set(target, prop, value, receiver)
+    } else if (typeof prop === "string") {
       return this.propertySet(prop, value)
     } else {
       return Reflect.set(target, prop, value, receiver)

--- a/src/reknow/Utils.spec.ts
+++ b/src/reknow/Utils.spec.ts
@@ -5,6 +5,8 @@ import {getSortedGT} from "./Utils"
 import {getSortedLE} from "./Utils"
 import {getSortedLT} from "./Utils"
 import {getSuperclass} from "./Utils"
+import {isGetter} from "./Utils"
+import {isSetter} from "./Utils"
 
 describe("Utils", () => {
   describe("sorted list methods", () => {
@@ -120,5 +122,87 @@ describe("Utils", () => {
     expect(getSuperclass(B)).toBe(A)
     expect(getSuperclass(C1)).toBe(B)
     expect(getSuperclass(C2)).toBe(B)
+  })
+  describe("isGetter", () => {
+    it("should return false for a nonexistent property", () => {
+      class A {}
+      const a = new A()
+      expect(isGetter(a, "val")).toBe(false)
+    })
+    it("should return false for a property set on the object", () => {
+      class A {
+        val!: string
+      }
+      const a = new A()
+      a.val = "abc"
+      expect(isGetter(a, "val")).toBe(false)
+    })
+    it("should return true for a getter on the class", () => {
+      class A {
+        get val() {
+          return 0
+        }
+      }
+      const a = new A()
+      expect(isGetter(a, "val")).toBe(true)
+    })
+    it("should return true for a getter on the superclass", () => {
+      class A {
+        get val() {
+          return 0
+        }
+      }
+      class A2 extends A {}
+      const a = new A2()
+      expect(isGetter(a, "val")).toBe(true)
+    })
+    it("should return false for a property shadowing a getter", () => {
+      class A {
+        get val() {
+          return 0
+        }
+      }
+      const a = new A()
+      Object.defineProperty(a, "val", {value: 10})
+      expect(isGetter(a, "val")).toBe(false)
+    })
+  })
+  describe("isSetter", () => {
+    it("should return false for a nonexistent property", () => {
+      class A {}
+      const a = new A()
+      expect(isSetter(a, "val")).toBe(false)
+    })
+    it("should return false for a property set on the object", () => {
+      class A {
+        val!: string
+      }
+      const a = new A()
+      a.val = "abc"
+      expect(isSetter(a, "val")).toBe(false)
+    })
+    it("should return true for a setter on the class", () => {
+      class A {
+        set val(v: string) {}
+      }
+      const a = new A()
+      expect(isSetter(a, "val")).toBe(true)
+    })
+    it("should return true for a setter on the superclass", () => {
+      class A {
+        set val(v: string) {}
+      }
+      class A2 extends A {}
+      const a = new A2()
+      expect(isSetter(a, "val")).toBe(true)
+    })
+    it("should return false for a property shadowing a setter", () => {
+      class A {
+        set val(v: string) {}
+      }
+      const a = new A()
+      Object.defineProperty(a, "val", {value: 10})
+      expect(isSetter(a, "val")).toBe(false)
+    })
   })
 })

--- a/src/reknow/Utils.ts
+++ b/src/reknow/Utils.ts
@@ -710,7 +710,7 @@ export function removeProperty<T>(target: Object, name: string) {
 
 export function addNonEnumerableProperty<T>(
   target: Object,
-  name: string|symbol,
+  name: string | symbol,
   value: T
 ) {
   const pd: PropertyDescriptor = {value, enumerable: false}
@@ -856,4 +856,36 @@ export function getSuperclass(clazz: Function): Function | null {
     return null
   }
   return superProto.constructor
+}
+
+// Returns true if the given object has the given name as a getter in
+// its prototype chain
+export function isGetter(obj: Object, prop: PropertyKey): boolean {
+  for (let o: Object | null = obj; o != null; o = Object.getPrototypeOf(o)) {
+    const pd = Object.getOwnPropertyDescriptor(o, prop)
+    if (pd != null) {
+      if (pd.get != null) {
+        return true
+      } else {
+        return false
+      }
+    }
+  }
+  return false
+}
+
+// Returns true if the given object has the given name as a setter in
+// its prototype chain
+export function isSetter(obj: Object, prop: PropertyKey): boolean {
+  for (let o: Object | null = obj; o != null; o = Object.getPrototypeOf(o)) {
+    const pd = Object.getOwnPropertyDescriptor(o, prop)
+    if (pd != null) {
+      if (pd.set != null) {
+        return true
+      } else {
+        return false
+      }
+    }
+  }
+  return false
 }

--- a/src/reknow/tests/Bug18.spec.ts
+++ b/src/reknow/tests/Bug18.spec.ts
@@ -15,25 +15,25 @@ import * as R from "../Reknow"
 // getting the primary key.
 
 describe("Bug18", () => {
-  it("should trigger the reaction that depends on a relationship that depends on another property", ()=>{
+  it("should trigger the reaction that depends on a relationship that depends on another property", () => {
     class A extends R.Entity {
-      w!:string
-      x!:string
+      w!: string
+      x!: string
 
-      @R.belongsTo(()=>A, "w", {foreignKey: "x"}) y1!:A
-      z1!:A
+      @R.belongsTo(() => A, "w", {foreignKey: "x"}) y1!: A
+      z1!: A
       @R.reaction setZ1() {
         this.z1 = this.y1
       }
 
-      @R.hasMany(()=>A, "x", {primaryKey: "w"}) y2!:Array<A>
-        z2!:Array<A>
-        @R.reaction setZ2() {
-          this.z2 = this.y2
-        }
+      @R.hasMany(() => A, "x", {primaryKey: "w"}) y2!: Array<A>
+      z2!: Array<A>
+      @R.reaction setZ2() {
+        this.z2 = this.y2
+      }
 
-      @R.hasOne(()=>A, "x", {primaryKey: "w"}) y3!:A
-      z3!:A
+      @R.hasOne(() => A, "x", {primaryKey: "w"}) y3!: A
+      z3!: A
       @R.reaction setZ3() {
         this.z3 = this.y3
       }
@@ -41,13 +41,13 @@ describe("Bug18", () => {
 
     class _AEntities extends R.Entities<A> {}
     const AEntities = new _AEntities(A)
-    const Entities = { A }
+    const Entities = {A}
     const stateManager = new R.StateManager({entities: Entities})
 
-    let _a1!:A
-    let a1!:A
-    let a2!:A
-    stateManager.action(()=>{
+    let _a1!: A
+    let a1!: A
+    let a2!: A
+    stateManager.action(() => {
       _a1 = new A()
       a1 = _a1.addEntity()
       a1.w = "abc"

--- a/src/reknow/tests/Transactions.spec.ts
+++ b/src/reknow/tests/Transactions.spec.ts
@@ -14,6 +14,10 @@ describe("Transactions", () => {
     @R.action setAge(age: number) {
       this.age = age
     }
+
+    set userName(userName: string) {
+      this.name = userName
+    }
   }
   class _Users extends R.Entities<User> {
     @R.action createUser() {
@@ -422,6 +426,34 @@ describe("Transactions", () => {
         .map((t) => R.stringifyTransaction(t))
         .join("\n")
       expect(resultStr).toEqual(expectedStr)
+    })
+  })
+  describe("Entity setter", () => {
+    let user!: User
+    beforeEach(() => {
+      user = Users.createUser()
+      transactions = []
+    })
+    it("should not report the setter call, but the underlying property setting", () => {
+      AppModel.action(() => (user.userName = "abc"))
+      const expected = [
+        {
+          action: {
+            type: "UnnamedAction",
+          },
+          stateChanges: [
+            {
+              type: "EntityPropertyChanged",
+              entityType: "User",
+              id: "user1",
+              property: "name",
+              newValue: "abc",
+              oldValue: "brad",
+            },
+          ],
+        },
+      ]
+      expect(transactions).toEqual(expected)
     })
   })
   describe("Service actions", () => {


### PR DESCRIPTION
Fixes #24

Now if a property is get or set on an Entity, and that property is actually a getter or setter, then the Proxied class just passes it on to the underlying target.